### PR TITLE
refactor: extract labels to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,7 @@
+package kinkgo
+
+// Config holds runtime configuration for the TestSuite.
+type Config struct {
+	// Labels is a list of labels to apply to the test suite.
+	Labels []string
+}

--- a/examples/simple_test/simple_test_suite_test.go
+++ b/examples/simple_test/simple_test_suite_test.go
@@ -21,7 +21,13 @@ var (
 )
 
 func TestSimpleTest(t *testing.T) {
-	kinkgo.Run(t, "SimpleTest Suite", new(SimpleTestSuite), "simple_test", "extra_label")
+	// Define test configuration
+	cfg := kinkgo.Config{
+		Labels: []string{"simple_test", "extra_label"},
+	}
+
+	// Run test suite
+	kinkgo.Run(t, "SimpleTest Suite", new(SimpleTestSuite), cfg)
 }
 
 type SimpleTestSuite struct{}

--- a/kinkgo.go
+++ b/kinkgo.go
@@ -17,7 +17,7 @@ type TestSuite interface {
 }
 
 // Run is a simple wrapper around ginkgo.RunSpecs that configures the runner for the kinkgo framework.
-func Run(t *testing.T, description string, suite TestSuite, labels ...string) {
+func Run(t *testing.T, description string, suite TestSuite, cfg Config) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	suiteCfg, reporterCfg := ginkgo.GinkgoConfiguration()
@@ -34,5 +34,5 @@ func Run(t *testing.T, description string, suite TestSuite, labels ...string) {
 		reporterCfg = ginkgotypes.ReporterConfig(hook.ModifyReporterConfig(kinkgotypes.ReporterConfig(reporterCfg)))
 	}
 
-	ginkgo.RunSpecs(t, description, ginkgo.Label(labels...), suiteCfg, reporterCfg)
+	ginkgo.RunSpecs(t, description, ginkgo.Label(cfg.Labels...), suiteCfg, reporterCfg)
 }


### PR DESCRIPTION
Extracts label definition to config struct. This change required to make future changes simpler